### PR TITLE
[P64065] 튜플

### DIFF
--- a/01.DataStructure/Stack&Queue/TH/64065/main.js
+++ b/01.DataStructure/Stack&Queue/TH/64065/main.js
@@ -1,0 +1,14 @@
+function solution(s) {
+  const arr = JSON.parse(s.replace(/{|}/g, (c) => (c === '{' ? '[' : ']'))).sort(
+    (a, b) => a.length - b.length
+  );
+  let que = arr.shift();
+
+  while (arr.length) {
+    const items = arr.shift();
+    const target = items.filter((x) => !que.includes(x));
+    que = [...que, ...target];
+  }
+
+  return que;
+}

--- a/01.DataStructure/Stack&Queue/TH/64065/튜플.md
+++ b/01.DataStructure/Stack&Queue/TH/64065/튜플.md
@@ -1,0 +1,35 @@
+# 튜플
+
+## 문제
+
+https://programmers.co.kr/learn/courses/30/lessons/64065
+
+## 풀이
+
+1. `{}` -> `[]`
+2. 길이가 작은 순으로 정렬
+3. `que`에서 `pop`한 아이템과 다른 아이템(들)을 찾고,
+4. `pop`한 아이템 뒤에 붙여준다.
+5. 이를 `que`에 다시 집어 넣는다.
+6. 이 과정을 `input` 배열 길이 만큼 반복한다.
+
+## 배운 점
+
+### String.replace(regex, replacer)
+
+`{}`를 `[]`로 교체하기 위해, 왼쪽과 오른쪽 중괄호를 각각 `replace`하여 대괄호로 교체해주었다.
+
+하지만, `replace`의 두번째 인자에 대체할 문자가 아닌 `callback 함수(replacer)`를 넣어주면, 첫번째 인자인 `regex`를 통과하는 애들을 모아서 분기처리를 해줄 수 있다.
+
+기존
+
+```js
+JSON.parse(s.replace(/{/g,'[').replace(/}/g,']')
+```
+
+replacer callback
+
+```js
+// /{|}/g -> { or } regex
+JSON.parse(s.replace(/{|}/g, (c) => (c === '{' ? '[' : ']')));
+```


### PR DESCRIPTION
# 튜플

## 문제

https://programmers.co.kr/learn/courses/30/lessons/64065

## 풀이

1. `{}` -> `[]`
2. 길이가 작은 순으로 정렬
3. `que`에서 `pop`한 아이템과 다른 아이템(들)을 찾고,
4. `pop`한 아이템 뒤에 붙여준다.
5. 이를 `que`에 다시 집어 넣는다.
6. 이 과정을 `input` 배열 길이 만큼 반복한다.

## 배운 점

### String.replace(regex, replacer)

`{}`를 `[]`로 교체하기 위해, 왼쪽과 오른쪽 중괄호를 각각 `replace`하여 대괄호로 교체해주었다.

하지만, `replace`의 두번째 인자에 대체할 문자가 아닌 `callback 함수(replacer)`를 넣어주면, 첫번째 인자인 `regex`를 통과하는 애들을 모아서 분기처리를 해줄 수 있다.

기존

```js
JSON.parse(s.replace(/{/g,'[').replace(/}/g,']')
```

replacer callback

```js
// /{|}/g -> { or } regex
JSON.parse(s.replace(/{|}/g, (c) => (c === '{' ? '[' : ']')));
```
